### PR TITLE
Device class change from 'light' to 'other'

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
       "en":"Vision Security",
       "nl":"Vision Security"
    },
-   "version":"1.2.0",
+   "version":"1.2.1",
    "compatibility":">=0.9.3",
    "description":{  
       "en":"Vision Security devices for Homey",
@@ -26,6 +26,10 @@
          {  
             "name":"Patrick van der Westen",
             "email":"pvdwesten@hotmail.com"
+         },
+         {  
+            "name":"Anne Baretta",
+            "email":"dev@baretta.nu"
          }
       ]
    },

--- a/app.json
+++ b/app.json
@@ -1,350 +1,409 @@
-{
-	"id": "com.visionsecurity",
-	"name": {
-		"en": "Vision Security",
-		"nl": "Vision Security"
-	},
-	"version": "1.2.0",
-	"compatibility": ">=0.9.3",
-	"description": {
-		"en": "Vision Security devices for Homey",
-		"nl": "Vision Security devices voor Homey"
-	},
-	"category": [ "security" ],
-	"images": {
-		"large": "/assets/images/large.jpg",
-		"small": "/assets/images/small.jpg"
-	},
-	"author": {
-		"name": "Serge Regoor",
-		"email": "serge@regoor.nl"
-	},
-    "contributors": {
-        "developers": [
-            {
-                "name": "Patrick van der Westen",
-                "email": "pvdwesten@hotmail.com"
+{  
+   "id":"com.visionsecurity",
+   "name":{  
+      "en":"Vision Security",
+      "nl":"Vision Security"
+   },
+   "version":"1.2.0",
+   "compatibility":">=0.9.3",
+   "description":{  
+      "en":"Vision Security devices for Homey",
+      "nl":"Vision Security devices voor Homey"
+   },
+   "category":[  
+      "security"
+   ],
+   "images":{  
+      "large":"/assets/images/large.jpg",
+      "small":"/assets/images/small.jpg"
+   },
+   "author":{  
+      "name":"Serge Regoor",
+      "email":"serge@regoor.nl"
+   },
+   "contributors":{  
+      "developers":[  
+         {  
+            "name":"Patrick van der Westen",
+            "email":"pvdwesten@hotmail.com"
+         }
+      ]
+   },
+   "drivers":[  
+      {  
+         "id":"ZM1601",
+         "name":{  
+            "en":"Battery Operated Siren",
+            "nl":"Battery Operated Siren"
+         },
+         "mobile":{  
+            "components":[  
+               {  
+                  "id":"icon",
+                  "capabilities":[ "onoff" ] 
+               },
+               {  
+                  "id":"toggle",
+                  "capabilities":[  
+                     "onoff"
+                  ],
+                  "options":{  
+                     "showTitle":true
+                  }
+               },
+               {  
+                  "id":"battery",
+                  "capabilities":[  
+                     "measure_battery"
+                  ],
+                  "options":{  
+                     "showTitle":true
+                  }
+               }
+            ]
+         },
+         "zwave":{  
+            "manufacturerId":265,
+            "productTypeId":8197,
+            "productId":[  
+               1283,
+               1285,
+               1288
+            ],
+            "requireSecure":false,
+            "learnmode":{  
+               "instruction":{  
+                  "en":"Press the (z-wave) button behind the battery door.",
+                  "nl":"Druk op de (z-wave) knop achter het deurtje tbv de batterijen."
+               }
+            },
+            "associationGroups":[  
+               1
+            ],
+            "defaultConfiguration":[  
+               {  
+                  "id":"siren_strobe_mode",
+                  "size":1,
+                  "value":0
+               },
+               {  
+                  "id":"alarm_auto_stop",
+                  "size":1,
+                  "value":0
+               }
+            ]
+         },
+         "class":"other",
+         "capabilities":[  
+            "onoff",
+            "measure_battery"
+         ],
+         "images":{  
+            "large":"/drivers/ZM1601/assets/images/large.png",
+            "small":"/drivers/ZM1601/assets/images/small.png"
+         },
+         "settings":[  
+            {  
+               "id":"siren_strobe_mode",
+               "type":"dropdown",
+               "label":{  
+                  "en":"Siren strobe mode",
+                  "nl":"Sirene en stroboscoop"
+               },
+               "value":"0",
+               "values":[  
+                  {  
+                     "id":"0",
+                     "label":{  
+                        "en":"Siren and strobe",
+                        "nl":"Sirene en stroboscoop"
+                     }
+                  },
+                  {  
+                     "id":"1",
+                     "label":{  
+                        "en":"Siren only",
+                        "nl":"Alleen sirene"
+                     }
+                  },
+                  {  
+                     "id":"2",
+                     "label":{  
+                        "en":"Strobe only",
+                        "nl":"Alleen stroboscoop"
+                     }
+                  }
+               ]
+            },
+            {  
+               "id":"alarm_auto_stop",
+               "type":"dropdown",
+               "label":{  
+                  "en":"Alarm auto stop",
+                  "nl":"Automatische alarm stop"
+               },
+               "value":"0",
+               "values":[  
+                  {  
+                     "id":"0",
+                     "label":{  
+                        "en":"30 seconds",
+                        "nl":"30 seconden"
+                     }
+                  },
+                  {  
+                     "id":"1",
+                     "label":{  
+                        "en":"60 seconds",
+                        "nl":"60 seconden"
+                     }
+                  },
+                  {  
+                     "id":"2",
+                     "label":{  
+                        "en":"120 seconds",
+                        "nl":"120 seconden"
+                     }
+                  },
+                  {  
+                     "id":"3",
+                     "label":{  
+                        "en":"No automatic stop",
+                        "nl":"Geen automatische stop"
+                     }
+                  }
+               ]
             }
-        ]
-    },
-	"drivers": [
-        {
-        	"id": "ZM1601",
-        	"name": {
-        		"en": "Battery Operated Siren",
-        		"nl": "Battery Operated Siren"
-        	},
-			"mobile": {
-				"components":[
-					{
-						"id": "icon",
-						"capabilities": [  ]
-					},
-					{
-						"id": "toggle",
-						"capabilities": ["onoff" ],
-						"options": { "showTitle": true }
-					},
-					{
-						"id": "battery",
-						"capabilities": ["measure_battery" ],
-						"options": { "showTitle": true }
-					}
-				]
-			},
-        	"zwave": {
-                "manufacturerId": 265,
-                "productTypeId": 8197,
-                "productId": [1283, 1285, 1288],
-                "requireSecure": false,
-                "learnmode": {
-                    "instruction": {
-                        "en": "Press the (z-wave) button behind the battery door.",
-                        "nl": "Druk op de (z-wave) knop achter het deurtje tbv de batterijen."
-                    }
-                },
-                "associationGroups": [ 1 ],
-                "defaultConfiguration": [
-                    {
-                        "id": "siren_strobe_mode",
-                        "size": 1,
-                        "value": 0
-                    },
-                    {
-                        "id": "alarm_auto_stop",
-                        "size": 1,
-                        "value": 0
-                    }
-                ]
-        	},
-        	"class": "other",
-        	"capabilities": [ "onoff", "measure_battery" ],
-             "images": {
-                "large": "/drivers/ZM1601/assets/images/large.png",
-                "small": "/drivers/ZM1601/assets/images/small.png"
-            },
-            "settings": [
-            	{
-                    "id": "siren_strobe_mode",
-                    "type": "dropdown",
-                    "label": {
-                        "en": "Siren strobe mode",
-                        "nl": "Sirene en stroboscoop"
-                    },
-                    "value": "0",
-                    "values": [
-                        {
-                            "id": "0",
-                            "label": {
-                                "en": "Siren and strobe",
-                                "nl": "Sirene en stroboscoop"
-                            }
-                        },
-                        {
-                            "id": "1",
-                            "label": {
-                                "en": "Siren only",
-                                "nl": "Alleen sirene"
-                            }
-                        },
-                        {
-                            "id": "2",
-                            "label": {
-                                "en": "Strobe only",
-                                "nl": "Alleen stroboscoop"
-                            }
-                        }
-                    ]
-                },
-            	{
-                    "id": "alarm_auto_stop",
-                    "type": "dropdown",
-                    "label": {
-                        "en": "Alarm auto stop",
-                        "nl": "Automatische alarm stop"
-                    },
-                    "value": "0",
-                    "values": [
-                        {
-                            "id": "0",
-                            "label": {
-                                "en": "30 seconds",
-                                "nl": "30 seconden"
-                            }
-                        },
-                        {
-                            "id": "1",
-                            "label": {
-                                "en": "60 seconds",
-                                "nl": "60 seconden"
-                            }
-                        },
-                        {
-                            "id": "2",
-                            "label": {
-                                "en": "120 seconds",
-                                "nl": "120 seconden"
-                            }
-                        },
-                        {
-                            "id": "3",
-                            "label": {
-                                "en": "No automatic stop",
-                                "nl": "Geen automatische stop"
-                            }
-                        }
-                    ]
-                }
+         ]
+      },
+      {  
+         "id":"ZM1602",
+         "name":{  
+            "en":"DC/AC Power Siren",
+            "nl":"DC/AC Power Siren"
+         },
+         "mobile":{  
+            "components":[  
+               {  
+                  "id":"icon",
+                  "capabilities":[ "onoff" ]
+               },
+               {  
+                  "id":"toggle",
+                  "capabilities":[ "onoff" ],
+                  "options":{  
+                     "showTitle":true
+                  }
+               }
             ]
-		},
-        {
-        	"id": "ZM1602",
-        	"name": {
-        		"en": "DC/AC Power Siren",
-        		"nl": "DC/AC Power Siren"
-        	},
-			"mobile": {
-				"components":[
-					{
-						"id": "icon",
-						"capabilities": [  ]
-					},
-					{
-						"id": "toggle",
-						"capabilities": ["onoff" ],
-						"options": { "showTitle": true }
-					}
-				]
-			},
-        	"zwave": {
-                "manufacturerId": 265,
-                "productTypeId": 12289,
-                "productId": [260],
-                "requireSecure": false,
-                "learnmode": {
-                    "instruction": {
-                        "en": "Press the (z-wave) button behind the battery door.",
-                        "nl": "Druk op de (z-wave) knop achter het deurtje tbv de batterijen."
-                    }
-                },
-                "associationGroups": [ 1 ],
-                "defaultConfiguration": [
-                    {
-                        "id": "siren_strobe_mode",
-                        "size": 1,
-                        "value": 0
-                    },
-                    {
-                        "id": "alarm_auto_stop",
-                        "size": 1,
-                        "value": 0
-                    }
-                ]
-        	},
-        	"class": "other",
-        	"capabilities": [ "onoff" ],
-             "images": {
-                "large": "/drivers/ZM1602/assets/images/large.png",
-                "small": "/drivers/ZM1602/assets/images/small.png"
+         },
+         "zwave":{  
+            "manufacturerId":265,
+            "productTypeId":12289,
+            "productId":[  
+               260
+            ],
+            "requireSecure":false,
+            "learnmode":{  
+               "instruction":{  
+                  "en":"Press the (z-wave) button behind the battery door.",
+                  "nl":"Druk op de (z-wave) knop achter het deurtje tbv de batterijen."
+               }
             },
-            "settings": [
-            	{
-                    "id": "siren_strobe_mode",
-                    "type": "dropdown",
-                    "label": {
-                        "en": "Siren strobe mode",
-                        "nl": "Sirene en stroboscoop"
-                    },
-                    "value": "0",
-                    "values": [
-                        {
-                            "id": "0",
-                            "label": {
-                                "en": "Siren and strobe",
-                                "nl": "Sirene en stroboscoop"
-                            }
-                        },
-                        {
-                            "id": "1",
-                            "label": {
-                                "en": "Siren only",
-                                "nl": "Alleen sirene"
-                            }
-                        },
-                        {
-                            "id": "2",
-                            "label": {
-                                "en": "Strobe only",
-                                "nl": "Alleen stroboscoop"
-                            }
-                        }
-                    ]
-                },
-            	{
-                    "id": "alarm_auto_stop",
-                    "type": "dropdown",
-                    "label": {
-                        "en": "Alarm auto stop",
-                        "nl": "Automatische alarm stop"
-                    },
-                    "value": "0",
-                    "values": [
-                        {
-                            "id": "0",
-                            "label": {
-                                "en": "30 seconds",
-                                "nl": "30 seconden"
-                            }
-                        },
-                        {
-                            "id": "1",
-                            "label": {
-                                "en": "60 seconds",
-                                "nl": "60 seconden"
-                            }
-                        },
-                        {
-                            "id": "2",
-                            "label": {
-                                "en": "120 seconds",
-                                "nl": "120 seconden"
-                            }
-                        },
-                        {
-                            "id": "3",
-                            "label": {
-                                "en": "No automatic stop",
-                                "nl": "Geen automatische stop"
-                            }
-                        }
-                    ]
-                }
+            "associationGroups":[  
+               1
+            ],
+            "defaultConfiguration":[  
+               {  
+                  "id":"siren_strobe_mode",
+                  "size":1,
+                  "value":0
+               },
+               {  
+                  "id":"alarm_auto_stop",
+                  "size":1,
+                  "value":0
+               }
             ]
-		},
-		{
-			"id": "ZG8101",
-			"name": {
-				"en": "Garage door Sensor",
-				"nl": "Garagedeur Sensor"
-			},
-			"zwave": {
-				"manufacturerId": 265,
-				"productTypeId": 8202,
-				"productId": [
-					2562
-				],
-				"learnmode": {
-					"image": "/drivers/ZG8101/assets/learnmode.svg",
-					"instruction": {
-						"en": "Press the button in your Door Sensor",
-						"nl": "Druk op de knop in de Deur Sensor"
-					}
-				},
-				"associationGroups": [
-					3
-				]
-			},
-			"class": "sensor",
-			"capabilities": [
-				"alarm_contact",
-				"measure_battery"
-			],
-			"images": {
-				"large": "/drivers/ZG8101/assets/images/large.png",
-				"small": "/drivers/ZG8101/assets/images/small.png"
-			},
-			"settings": [
-				{
-					"id": "input_alarm_cancellation_delay",
-					"type": "number",
-					"label": {
-						"en": "Input Alarm Cancellation Delay",
-						"nl": "Ingang Alarm Annulerings Vertraging"
-					},
-					"hint": {
-						"en": "Sets the time (in seconds) then the alarm of the input wel cancel.\nRange: 0 - 65535",
-						"nl": "Zet de tijd (in seconden) wanneer de ingangs alarm zal annuleren.\nBereik: 0 - 65535"
-					},
-					"attr": {
-						"min": 0,
-						"max": 65535
-					},
-					"value": 0
-				},
-				{
-					"id": "led_status",
-					"type": "checkbox",
-					"label": {
-						"en": "Status Change With LED",
-						"nl": "Status Veranderen Met LED"
-					},
-					"hint": {
-						"en": "Enable/Disable if the LED shows if the state changes.",
-						"nl": "Zet Aan/Uit of de LED de status verandering weergeeft."
-					},
-					"value": true
-				}
-			]
-		}
-	]
+         },
+         "class":"other",
+         "capabilities":[  
+            "onoff"
+         ],
+         "images":{  
+            "large":"/drivers/ZM1602/assets/images/large.png",
+            "small":"/drivers/ZM1602/assets/images/small.png"
+         },
+         "settings":[  
+            {  
+               "id":"siren_strobe_mode",
+               "type":"dropdown",
+               "label":{  
+                  "en":"Siren strobe mode",
+                  "nl":"Sirene en stroboscoop"
+               },
+               "value":"0",
+               "values":[  
+                  {  
+                     "id":"0",
+                     "label":{  
+                        "en":"Siren and strobe",
+                        "nl":"Sirene en stroboscoop"
+                     }
+                  },
+                  {  
+                     "id":"1",
+                     "label":{  
+                        "en":"Siren only",
+                        "nl":"Alleen sirene"
+                     }
+                  },
+                  {  
+                     "id":"2",
+                     "label":{  
+                        "en":"Strobe only",
+                        "nl":"Alleen stroboscoop"
+                     }
+                  }
+               ]
+            },
+            {  
+               "id":"alarm_auto_stop",
+               "type":"dropdown",
+               "label":{  
+                  "en":"Alarm auto stop",
+                  "nl":"Automatische alarm stop"
+               },
+               "value":"0",
+               "values":[  
+                  {  
+                     "id":"0",
+                     "label":{  
+                        "en":"30 seconds",
+                        "nl":"30 seconden"
+                     }
+                  },
+                  {  
+                     "id":"1",
+                     "label":{  
+                        "en":"60 seconds",
+                        "nl":"60 seconden"
+                     }
+                  },
+                  {  
+                     "id":"2",
+                     "label":{  
+                        "en":"120 seconds",
+                        "nl":"120 seconden"
+                     }
+                  },
+                  {  
+                     "id":"3",
+                     "label":{  
+                        "en":"No automatic stop",
+                        "nl":"Geen automatische stop"
+                     }
+                  }
+               ]
+            }
+         ]
+      },
+      {  
+         "id":"ZG8101",
+         "name":{  
+            "en":"Garage door Sensor",
+            "nl":"Garagedeur Sensor"
+         },
+         "zwave":{  
+            "manufacturerId":265,
+            "productTypeId":8202,
+            "productId":[  
+               2562
+            ],
+            "learnmode":{  
+               "image":"/drivers/ZG8101/assets/learnmode.svg",
+               "instruction":{  
+                  "en":"Press the button in your Door Sensor",
+                  "nl":"Druk op de knop in de Deur Sensor"
+               }
+            },
+            "associationGroups":[  
+               3
+            ]
+         },
+         "class":"sensor",
+         "capabilities":[  
+            "alarm_contact",
+            "measure_battery"
+         ],
+         "images":{  
+            "large":"/drivers/ZG8101/assets/images/large.png",
+            "small":"/drivers/ZG8101/assets/images/small.png"
+         },
+         "settings":[  
+            {  
+               "id":"input_alarm_cancellation_delay",
+               "type":"number",
+               "label":{  
+                  "en":"Input Alarm Cancellation Delay",
+                  "nl":"Ingang Alarm Annulerings Vertraging"
+               },
+               "hint":{  
+                  "en":"Sets the time (in seconds) then the alarm of the input wel cancel.\nRange: 0 - 65535",
+                  "nl":"Zet de tijd (in seconden) wanneer de ingangs alarm zal annuleren.\nBereik: 0 - 65535"
+               },
+               "attr":{  
+                  "min":0,
+                  "max":65535
+               },
+               "value":0
+            },
+            {  
+               "id":"led_status",
+               "type":"checkbox",
+               "label":{  
+                  "en":"Status Change With LED",
+                  "nl":"Status Veranderen Met LED"
+               },
+               "hint":{  
+                  "en":"Enable/Disable if the LED shows if the state changes.",
+                  "nl":"Zet Aan/Uit of de LED de status verandering weergeeft."
+               },
+               "value":true
+            }
+         ]
+      }
+   ],
+   "flow":{  
+      "actions":[  
+         {  
+            "id":"turn_alarm_on",
+            "title":{  
+               "en":"Turn siren on",
+               "nl":"Zet sirene aan"
+            },
+            "args":[  
+               {  
+                  "name":"device",
+                  "type":"device",
+                  "filter":"driver_id=ZM1601"
+               }
+            ]
+         },
+         {  
+            "id":"turn_alarm_off",
+            "title":{  
+               "en":"Turn off siren",
+               "nl":"Zet sirene uit"
+            },
+            "args":[  
+               {  
+                  "name":"device",
+                  "type":"device",
+                  "filter":"driver_id=ZM1601"
+               }
+            ]
+         }
+      ]
+   }
 }

--- a/drivers/ZM1601/driver.js
+++ b/drivers/ZM1601/driver.js
@@ -8,29 +8,29 @@ const ZwaveDriver = require('homey-zwavedriver');
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
 	capabilities: {
-		'onoff': {
-			'command_class': 'COMMAND_CLASS_SWITCH_BINARY',
-			'command_get': 'SWITCH_BINARY_GET',
-			'command_set': 'SWITCH_BINARY_SET',
-			'command_set_parser': value => {
-				return {
-					'Switch Value': (value > 0) ? 255 : 0
-				};
-			},
-			'command_report': 'SWITCH_BINARY_REPORT',
-			'command_report_parser': report => report['Value'] === 'on/enable'
-		},
-		'measure_battery': {
-			'command_class': 'COMMAND_CLASS_BATTERY',
-			'command_get': 'BATTERY_GET',
-			'command_report': 'BATTERY_REPORT',
-			'command_report_parser': report => {
-				if (report['Battery Level'] === "battery low warning") return 1;
-				
-				return report['Battery Level (Raw)'][0];
-			}
-		}
-	},
+               'onoff': {
+                        'command_class': 'COMMAND_CLASS_SWITCH_BINARY',
+                        'command_get': 'SWITCH_BINARY_GET',
+                        'command_set': 'SWITCH_BINARY_SET',
+                        'command_set_parser': value => {
+                                return {
+                                        'Switch Value': (value > 0) ? 255 : 0
+                                };
+                        },
+                        'command_report': 'SWITCH_BINARY_REPORT',
+                        'command_report_parser': report => report['Value'] === 'on/enable'
+                },
+                'measure_battery': {
+                        'command_class': 'COMMAND_CLASS_BATTERY',
+                        'command_get': 'BATTERY_GET',
+                        'command_report': 'BATTERY_REPORT',
+                        'command_report_parser': report => {
+                                if (report['Battery Level'] === "battery low warning") return 1;
+
+                                return report['Battery Level (Raw)'][0];
+                        }
+                }
+        },
 	settings: {
 		'siren_strobe_mode': {
 			index: 1,
@@ -42,3 +42,36 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		}
 	}
 });
+
+Homey.manager('flow').on('action.turn_alarm_on', function( callback, args ){
+	Homey.log('');
+	Homey.log('on flow action.action.turn_alarm_on');
+	Homey.log('args', args);
+
+	Homey.manager('drivers').getDriver('ZM1601').capabilities.onoff.set(args.device, true, function (err, data) {
+		Homey.log('');
+		Homey.log('Homey.manager(drivers).getDriver(ZM1601).capabilities.onoff.set');
+		Homey.log('err', err);
+		Homey.log('data', data);
+		if (err) callback (err, false);
+	});
+
+	callback( null, true );
+});
+
+Homey.manager('flow').on('action.turn_alarm_off', function( callback, args ){
+	Homey.log('');
+	Homey.log('on flow action.action.turn_alarm_on');
+	Homey.log('args', args);
+
+	Homey.manager('drivers').getDriver('ZM1601').capabilities.onoff.set(args.device, false, function (err, data) {
+		Homey.log('');
+		Homey.log('Homey.manager(drivers).getDriver(ZM1601).capabilities.onoff.set');
+		Homey.log('err', err);
+		Homey.log('data', data);
+		if (err) callback (err, false);
+	});
+
+	callback( null, true );
+});
+

--- a/drivers/ZM1602/driver.js
+++ b/drivers/ZM1602/driver.js
@@ -32,3 +32,36 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		}
 	}
 });
+
+Homey.manager('flow').on('action.turn_alarm_on', function( callback, args ){
+        Homey.log('');
+        Homey.log('on flow action.action.turn_alarm_on');
+        Homey.log('args', args);
+
+        Homey.manager('drivers').getDriver('ZM1601').capabilities.onoff.set(args.device, true, function (err, data) {
+                Homey.log('');
+                Homey.log('Homey.manager(drivers).getDriver(ZM1601).capabilities.onoff.set');
+                Homey.log('err', err);
+                Homey.log('data', data);
+                if (err) callback (err, false);
+        });
+
+        callback( null, true );
+});
+
+Homey.manager('flow').on('action.turn_alarm_off', function( callback, args ){
+        Homey.log('');
+        Homey.log('on flow action.action.turn_alarm_on');
+        Homey.log('args', args);
+
+        Homey.manager('drivers').getDriver('ZM1601').capabilities.onoff.set(args.device, false, function (err, data) {
+                Homey.log('');
+                Homey.log('Homey.manager(drivers).getDriver(ZM1601).capabilities.onoff.set');
+                Homey.log('err', err);
+                Homey.log('data', data);
+                if (err) callback (err, false);
+        });
+
+        callback( null, true );
+});
+

--- a/drivers/ZM1602/driver.js
+++ b/drivers/ZM1602/driver.js
@@ -38,9 +38,9 @@ Homey.manager('flow').on('action.turn_alarm_on', function( callback, args ){
         Homey.log('on flow action.action.turn_alarm_on');
         Homey.log('args', args);
 
-        Homey.manager('drivers').getDriver('ZM1601').capabilities.onoff.set(args.device, true, function (err, data) {
+        Homey.manager('drivers').getDriver('ZM1602').capabilities.onoff.set(args.device, true, function (err, data) {
                 Homey.log('');
-                Homey.log('Homey.manager(drivers).getDriver(ZM1601).capabilities.onoff.set');
+                Homey.log('Homey.manager(drivers).getDriver(ZM1602).capabilities.onoff.set');
                 Homey.log('err', err);
                 Homey.log('data', data);
                 if (err) callback (err, false);
@@ -54,9 +54,9 @@ Homey.manager('flow').on('action.turn_alarm_off', function( callback, args ){
         Homey.log('on flow action.action.turn_alarm_on');
         Homey.log('args', args);
 
-        Homey.manager('drivers').getDriver('ZM1601').capabilities.onoff.set(args.device, false, function (err, data) {
+        Homey.manager('drivers').getDriver('ZM1602').capabilities.onoff.set(args.device, false, function (err, data) {
                 Homey.log('');
-                Homey.log('Homey.manager(drivers).getDriver(ZM1601).capabilities.onoff.set');
+                Homey.log('Homey.manager(drivers).getDriver(ZM1602).capabilities.onoff.set');
                 Homey.log('err', err);
                 Homey.log('data', data);
                 if (err) callback (err, false);


### PR DESCRIPTION
The device class has been changed from 'light' to 'other', and on/off flow actions have been added to both app.json as well as the two siren drivers (ZM1601 and ZM1602). ZM1601 has been successfully tested, ZM1602 has not been verified.

With this change the sirens can only be used in the action column of flows.

I have also added the on/off toggle capability to the icon in the mobile view, it annoyed me that clicking on the icon didn't do anything ;-)